### PR TITLE
Update dumbno.py usage to match README

### DIFF
--- a/dumbno.py
+++ b/dumbno.py
@@ -355,7 +355,7 @@ def run_stats(config, setup=False):
 
 def main():
     if len(sys.argv) < 2:
-        sys.stderr.write("Usage: %s dumbno.ini [setup|stats]\n" % sys.argv[0])
+        sys.stderr.write("Usage: %s dumbno.cfg [setup|stats]\n" % sys.argv[0])
         sys.exit(1)
     cfg_file = sys.argv[1]
     setup = len(sys.argv) == 3 and sys.argv[2] == 'setup'


### PR DESCRIPTION
The README usage indicates dumbo should be used like this:
```
./dumbno.py dumbno.cfg setup
```
Whereas `dumbno.py` outputs usage as:
```
./dumbno.py dumbno.ini setup
```
This pull request updates `dumbno.py` to match the README